### PR TITLE
make !play add to queue if more songs are queued

### DIFF
--- a/StreamMusicBot/Services/MusicService.cs
+++ b/StreamMusicBot/Services/MusicService.cs
@@ -52,7 +52,8 @@ namespace StreamMusicBot.Services
             foreach (var track in tracks)
             {
                 var isPlaying = _player.PlayerState.Equals(PlayerState.Playing);
-                if (isPlaying)
+                var isEmpty = _player.Queue.Count == 0;
+                if (isPlaying || !isEmpty)
                     _player.Queue.Enqueue(track);
                 else
                     await _player.PlayAsync(track);


### PR DESCRIPTION
If the player state is paused, but songs are still queued, it will simply append to the queue instead overwriting the current playing song